### PR TITLE
Fixing #21 - C# 1591 warnings during the build

### DIFF
--- a/packages/ove-asset-manager/src/OVE.Service.AssetManager/OVE.Service.AssetManager.csproj
+++ b/packages/ove-asset-manager/src/OVE.Service.AssetManager/OVE.Service.AssetManager.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>C:\Code\OVE\ove-services\packages\ove-asset-manager\src\OVE.Service.AssetManager\OVE.Service.AssetManager.xml</DocumentationFile>
+    <noWarn>1591</noWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/ove-service-imagetiles/src/OVE.Service.ImageTiles/OVE.Service.ImageTiles.csproj
+++ b/packages/ove-service-imagetiles/src/OVE.Service.ImageTiles/OVE.Service.ImageTiles.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>C:\Code\OVE\packages\ove-service-imagetiles\src\OVE.Service.ImageTiles\OVE.Service.ImageTiles.xml</DocumentationFile>
+    <noWarn>1591</noWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We have Swagger documentation and good enough code comments, the warnings are redundant and also unavoidable. This PR adds suppression of this warning [as recommended by the .NET community](https://dev.to/coolgoose/how-to-disable-notifications-in-aspnet-core-20-for-missing-xml-comment-for-publicly-visible-type-or-member-29ab).