### PR TITLE
Updating dependencies

### DIFF
--- a/packages/ove-asset-manager/src/OVE.Service.AssetManager/OVE.Service.AssetManager.csproj
+++ b/packages/ove-asset-manager/src/OVE.Service.AssetManager/OVE.Service.AssetManager.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.24.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.27.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/packages/ove-service-imagetiles/src/OVE.Service.ImageTiles/OVE.Service.ImageTiles.csproj
+++ b/packages/ove-service-imagetiles/src/OVE.Service.ImageTiles/OVE.Service.ImageTiles.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.24.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.27.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.6" />
-    <PackageReference Include="NetVips" Version="1.0.4" />
+    <PackageReference Include="NetVips" Version="1.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Confirmed netvips v1.05 now works on windows
also update AWS SDK 
